### PR TITLE
Add Smithery CLI Installation Instructions & Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # DNStwist MCP Server
+[![smithery badge](https://smithery.ai/badge/@burtthecoder/mcp-dnstwist)](https://smithery.ai/server/@burtthecoder/mcp-dnstwist)
 
 A Model Context Protocol (MCP) server for [dnstwist](https://github.com/elceef/dnstwist), a powerful DNS fuzzing tool that helps detect typosquatting, phishing, and corporate espionage. This server provides tools for analyzing domain permutations and identifying potentially malicious domains. It is designed to integrate seamlessly with MCP-compatible applications like [Claude Desktop](https://claude.ai).
 
 <a href="https://glama.ai/mcp/servers/it7izu3ufb"><img width="380" height="200" src="https://glama.ai/mcp/servers/it7izu3ufb/badge" alt="mcp-dnstwist MCP server" /></a>
-[![smithery badge](https://smithery.ai/badge/@burtthecoder/mcp-dnstwist)](https://smithery.ai/server/@burtthecoder/mcp-dnstwist)
 
 
 ## ⚠️ Warning
@@ -31,6 +31,7 @@ To install DNStwist for Claude Desktop automatically via [Smithery](https://smit
 npx -y @smithery/cli install @burtthecoder/mcp-dnstwist --client claude
 ```
 
+### Installing Manually
 1. Install Docker:
    - macOS: Install [Docker Desktop](https://www.docker.com/products/docker-desktop)
    - Linux: Follow the [Docker Engine installation guide](https://docs.docker.com/engine/install/)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A Model Context Protocol (MCP) server for [dnstwist](https://github.com/elceef/dnstwist), a powerful DNS fuzzing tool that helps detect typosquatting, phishing, and corporate espionage. This server provides tools for analyzing domain permutations and identifying potentially malicious domains. It is designed to integrate seamlessly with MCP-compatible applications like [Claude Desktop](https://claude.ai).
 
 <a href="https://glama.ai/mcp/servers/it7izu3ufb"><img width="380" height="200" src="https://glama.ai/mcp/servers/it7izu3ufb/badge" alt="mcp-dnstwist MCP server" /></a>
+[![smithery badge](https://smithery.ai/badge/@burtthecoder/mcp-dnstwist)](https://smithery.ai/server/@burtthecoder/mcp-dnstwist)
+
 
 ## ⚠️ Warning
 
@@ -20,6 +22,14 @@ This tool is designed for legitimate security research purposes. Please:
 - macOS, Linux, or Windows with Docker Desktop installed
 
 ## Quick Start
+
+### Installing via Smithery
+
+To install DNStwist for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@burtthecoder/mcp-dnstwist):
+
+```bash
+npx -y @smithery/cli install @burtthecoder/mcp-dnstwist --client claude
+```
 
 1. Install Docker:
    - macOS: Install [Docker Desktop](https://www.docker.com/products/docker-desktop)


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install DNStwist for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@burtthecoder/mcp-dnstwist

Let me know if any tweaks have to be made!